### PR TITLE
Add openConversation documentation

### DIFF
--- a/SDK_reference.md
+++ b/SDK_reference.md
@@ -234,3 +234,18 @@ content from your app with their friends.
 
 * `title`: the title of the message being shared
 * `message`: the message that will be sent when the user picks a target app in the Share flow
+
+
+
+## Open conversation (Coming Soon)
+
+Open a conversation:
+
+```typescript
+Pi.openConversation(conversationId: string): void;
+```
+
+Use this method to open a Pi conversation/chat thread, enabling your users to chat
+with other Pi users.
+
+* `conversationId`: the id of the conversation to open


### PR DESCRIPTION
I'm not 100% sure on how `Pi.openConversation` works (although I think I might have a basic idea?), but hopefully one of the Pi Apps Platform devs can propose any changes here so that the documentation includes all available methods. It's probably a good idea to have the documentation there even if the feature is simply exposed in the JavaScript SDK but not yet fully implemented (why I put a "Coming Soon" notice, which I can delete if necessary) so that developers can start planning features. Please let me know what you think. 