### PR TITLE
Create trust_security_model.md

### DIFF
--- a/trust_security_model.md
+++ b/trust_security_model.md
@@ -1,0 +1,177 @@
+# Pi Network Trust & Security Model
+## Unified Verification, Payment, Token, and App Integrity Framework
+
+---
+
+## 1. Purpose
+
+This document defines the **end-to-end trust, security, and verification model**
+used across:
+- Pi Browser
+- Pi Apps Frontend SDK
+- Pi Platform APIs
+- Pi Blockchain
+- PiNet Metadata
+- Token Minting & Payments
+
+Its goal is to provide a **deterministic, auditable, and attack-resilient**
+architecture without relying on smart contracts by default.
+
+---
+
+## 2. Core Trust Assumptions
+
+Pi Network security is built on five immutable trust anchors:
+
+1. **User Identity**
+   - Verified Pi account
+   - KYC-backed (when required)
+   - Bound to Pi Browser runtime
+
+2. **Application Identity**
+   - Registered in Pi Developer Portal
+   - App-specific API keys
+   - Domain & origin binding
+
+3. **Platform Authority**
+   - Pi Platform servers
+   - Signature-based API responses
+   - Payment state arbitration
+
+4. **Blockchain Finality**
+   - Stellar-based consensus (Pi Mainnet)
+   - Transaction immutability
+   - Deterministic ledger ordering
+
+5. **Metadata Verifiability**
+   - PiNet metadata anchoring
+   - Token mint provenance
+   - External indexer compatibility
+
+---
+
+## 3. Authentication Security Flow
+Security properties:
+- No private keys exposed to apps
+- No session spoofing outside Pi Browser
+- Scope-limited permissions (e.g. payments)
+
+---
+
+## 4. Payment Security Model
+
+### 4.1 User → App Payment (U2A)
+
+**Three-Phase Commit Model**
+
+1. Client Intent
+   - `Pi.createPayment()`
+   - User signs via Pi Wallet
+
+2. Server Approval
+   - App backend validates intent
+   - Calls Pi Platform API
+   - Prevents replay & double-spend
+
+3. Server Completion
+   - Blockchain confirmation
+   - Final acknowledgment to Pi servers
+
+📌 **Key Property**  
+> A payment is invalid unless **both** server approval AND blockchain settlement succeed.
+
+---
+
+### 4.2 App → User Payment (A2U)
+
+- Requires backend SDK
+- Requires custody-capable app wallet
+- Requires strict rate & fraud controls
+
+---
+
+## 5. Token Minting Trust Model
+
+Token minting on Pi Network follows:
+
+- Explicit issuer identity
+- Fixed or bounded supply rules
+- PiNet metadata anchoring
+- Ledger-based traceability
+
+Security guarantees:
+- No anonymous mint authority
+- Full issuance audit trail
+- External indexer compatibility
+
+---
+
+## 6. PiNet Metadata Integrity
+
+PiNet metadata acts as:
+- A **semantic layer** above raw ledger data
+- A bridge to Web2 & Web3 tooling
+
+Integrity rules:
+- Immutable after anchoring
+- Hash-verifiable
+- Cross-referenced with ledger txid
+
+---
+
+## 7. Threat Model & Mitigations
+
+| Threat | Mitigation |
+|-----|-----------|
+| Fake payments | Server-side approval |
+| Replay attack | Payment ID uniqueness |
+| Frontend tampering | Pi Browser sandbox |
+| API spoofing | Signed platform responses |
+| Double spend | Ledger finality |
+| App impersonation | Developer Portal binding |
+
+---
+
+## 8. Why Smart Contracts Are Optional
+
+Pi Network favors:
+- Real commerce
+- Human-verified users
+- Regulated payment flow
+
+Smart contracts may be added later (e.g. DEX),
+but **are not required** for secure value transfer.
+
+This reduces:
+- Attack surface
+- Contract exploits
+- Gas & execution risk
+
+---
+
+## 9. Audit & Verification Capability
+
+Any third party can verify:
+- Payment txid on-chain
+- App identity via Developer Portal
+- Token provenance via PiNet metadata
+
+This enables:
+- Independent auditing
+- Regulatory compliance
+- Institutional integration
+
+---
+
+## 10. Summary
+
+Pi Network security is:
+- Identity-centric
+- Server-verified
+- Ledger-final
+- Metadata-auditable
+- Commerce-first
+
+This model prioritizes **real-world usability** without sacrificing cryptographic integrity.
+
+---


### PR DESCRIPTION
This pull request introduces a new documentation file: trust_security_model.md.
The document provides a unified, end-to-end explanation of trust, security, and verification across the Pi ecosystem, including:
Pi Browser & Frontend JS SDK
Pi Platform authentication and payments
App backend approval/completion flows
Pi Blockchain ledger finality
PiNet metadata and token minting
It consolidates concepts that are currently documented separately (auth, payments, tokens, PiNet) into a single architectural trust model, including:
Authentication and identity guarantees
Server-verified payment flows
Threat model and mitigations
Rationale for Pi’s non-smart-contract-first design
This change:
Adds one documentation file only
Introduces no API or SDK changes
Is intended to improve clarity for developers, auditors, and reviewers